### PR TITLE
Proposed property to link project to supporting foras

### DIFF
--- a/schema/doap.rdf
+++ b/schema/doap.rdf
@@ -375,6 +375,14 @@
 	<rdfs:range rdf:resource="http://rdfs.org/sioc/ns#Container" />
 </rdf:Property>
 
+<rdf:Property rdf:about="http://usefulinc.com/ns/doap#developer-forum">
+	<rdfs:isDefinedBy rdf:resource="http://usefulinc.com/ns/doap#" />
+	<rdfs:label xml:lang="en">developer forum</rdfs:label>
+	<rdfs:comment xml:lang="en">A forum or community for developers of this project.</rdfs:comment>
+	<rdfs:domain rdf:resource="http://usefulinc.com/ns/doap#Project" />
+	<rdfs:range rdf:resource="http://rdfs.org/sioc/ns#Container" />
+</rdf:Property>
+
 
 <rdf:Property rdf:about="http://usefulinc.com/ns/doap#category">
 	<rdfs:isDefinedBy rdf:resource="http://usefulinc.com/ns/doap#" />

--- a/schema/doap.rdf
+++ b/schema/doap.rdf
@@ -367,6 +367,15 @@
 	<rdfs:domain rdf:resource="http://usefulinc.com/ns/doap#Project" />
 </rdf:Property>
 
+<rdf:Property rdf:about="http://usefulinc.com/ns/doap#support-forum">
+	<rdfs:isDefinedBy rdf:resource="http://usefulinc.com/ns/doap#" />
+	<rdfs:label xml:lang="en">supporting forum</rdfs:label>
+	<rdfs:comment xml:lang="en">A forum or community that supports this project.</rdfs:comment>
+	<rdfs:domain rdf:resource="http://usefulinc.com/ns/doap#Project" />
+	<rdfs:range rdf:resource="http://rdfs.org/sioc/ns#Container" />
+</rdf:Property>
+
+
 <rdf:Property rdf:about="http://usefulinc.com/ns/doap#category">
 	<rdfs:isDefinedBy rdf:resource="http://usefulinc.com/ns/doap#" />
 	<rdfs:label xml:lang="en">category</rdfs:label>


### PR DESCRIPTION
Hi!

We're using DOAP pretty operationally these days to package Perl modules. Project metadata, user-facing changelogs, the dependency resolution, the links to github repos and bugtracker, etc is all generated from that. So, it is pretty much driving the whole distribution.

However, I needed to link the project to an IRC channel that we use to support it, and rather than introduce YA specific property about that, I figured it would be better to link to sioc:Container, which again has a sioc:Forum as subclass, which again has sioct:ChatChannel. 

Moreover, this can be used in a wide variety of scenarios, as it can be used to link to everything from whole bulletin boards, to individual IRC channels. And everything in between. Thus, I think it makes a nice addition to the much used specific properties.

A similar property doap:developers-forum might also be appropriate, pretty much for the same reasons. :-)

Cheers,

Kjetil 
