### PR TITLE
Feature/reverse repo

### DIFF
--- a/schema/doap.rdf
+++ b/schema/doap.rdf
@@ -417,6 +417,7 @@
         <rdfs:comment xml:lang="pt">Repositório do código fonte.</rdfs:comment>
 	<rdfs:domain rdf:resource="http://usefulinc.com/ns/doap#Project" />
 	<rdfs:range rdf:resource="http://usefulinc.com/ns/doap#Repository" />
+	<owl:inverseOf rdf:resource="http://usefulinc.com/ns/doap#repositoryOf" />
 </rdf:Property>
 
 <rdf:Property rdf:about="http://usefulinc.com/ns/doap#repositoryOf">
@@ -425,6 +426,7 @@
 	<rdfs:comment xml:lang="en">The project that uses a repository.</rdfs:comment>
 	<rdfs:range rdf:resource="http://usefulinc.com/ns/doap#Project" />
 	<rdfs:domain rdf:resource="http://usefulinc.com/ns/doap#Repository" />
+	<owl:inverseOf rdf:resource="http://usefulinc.com/ns/doap#repository" />
 </rdf:Property>
 
 <rdf:Property rdf:about="http://usefulinc.com/ns/doap#anon-root">

--- a/schema/doap.rdf
+++ b/schema/doap.rdf
@@ -419,6 +419,14 @@
 	<rdfs:range rdf:resource="http://usefulinc.com/ns/doap#Repository" />
 </rdf:Property>
 
+<rdf:Property rdf:about="http://usefulinc.com/ns/doap#repositoryOf">
+	<rdfs:isDefinedBy rdf:resource="http://usefulinc.com/ns/doap#" />
+	<rdfs:label xml:lang="en">repository of</rdfs:label>
+	<rdfs:comment xml:lang="en">The project that uses a repository.</rdfs:comment>
+	<rdfs:range rdf:resource="http://usefulinc.com/ns/doap#Project" />
+	<rdfs:domain rdf:resource="http://usefulinc.com/ns/doap#Repository" />
+</rdf:Property>
+
 <rdf:Property rdf:about="http://usefulinc.com/ns/doap#anon-root">
 	<rdfs:isDefinedBy rdf:resource="http://usefulinc.com/ns/doap#" />
 	<rdfs:label xml:lang="en">anonymous root</rdfs:label>


### PR DESCRIPTION
Hi,

It would be useful to be able to determine the project using a repository given only the URI for the repository when you do not have the full RDF graph available to query. This pull request adds an inverse property "doap:repositoryOf".

Thanks,
Iain.
