### PR TITLE
Fix a few warnings about deprecated options

### DIFF
--- a/validator/Makefile
+++ b/validator/Makefile
@@ -17,7 +17,7 @@ doap.rng: doap.rnc
 	trang -I rnc -O rng doap.rnc doap.rng
 
 validator.exe: $(SRCS) ../schema/doap.rdf doap.rng
-	$(CSC) -g -o validator.exe $(SRCS) -r:Redland.dll \
+	$(CSC) -debug -out:validator.exe $(SRCS) -r:Redland.dll \
 		-resource:../schema/doap.rdf,doap.rdf \
 		-resource:doap.rng,doap.rng \
 		-r:Commons.Xml.Relaxng

--- a/viewer/Makefile
+++ b/viewer/Makefile
@@ -14,7 +14,7 @@ clean:
 	rm $(EXES)
 
 viewer.exe: $(SRCS) ../schema/doap.rdf style.xsl
-	$(CSC) -g -o viewer.exe $(SRCS) -r:Redland.dll \
+	$(CSC) -debug -out:viewer.exe $(SRCS) -r:Redland.dll \
 		-resource:../schema/doap.rdf,doap.rdf \
 		-resource:style.xsl,style.xsl
 


### PR DESCRIPTION
These were found using Mono 5.0.0 on ArchLinux.